### PR TITLE
Update proxy-agent

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "3.0.0",
   "description": "Stream interface for streaming webtask logs for node and the browser",
   "main": "index.js",
+  "engines": {
+    "node": ">=6"
+  },
   "dependencies": {
     "proxy-agent": "^3.0.3",
     "request-stream": "^1.2.2"

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "webtask-log-stream",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "Stream interface for streaming webtask logs for node and the browser",
   "main": "index.js",
   "dependencies": {
-    "proxy-agent": "^2.0.0",
+    "proxy-agent": "^3.0.3",
     "request-stream": "^1.2.2"
   },
   "scripts": {},


### PR DESCRIPTION
Related to https://github.com/TooTallNate/node-proxy-agent/pull/30

Updates proxy-agent in order to remove socks deprecation warnings and to enable socks v2.

A new major version is required as moving to a newer version of socks means dropping Node < 6 support.